### PR TITLE
Fixed issue with door not closing after API update

### DIFF
--- a/MyQ.GarageDoorOpener.SmartDevice.groovy
+++ b/MyQ.GarageDoorOpener.SmartDevice.groovy
@@ -115,7 +115,7 @@ def open()  {
 	updateDeviceStatus(4)
 }
 def close() { 
-	parent.sendCommand(this, "desireddoorstate", 2) 
+	parent.sendCommand(this, "desireddoorstate", 0) 
 	state.polling.runNow = true
 	updateDeviceStatus(5)
 }


### PR DESCRIPTION
Chamberlain seems to have changed the desireddoorstate value from 2 to 0
for closing the door. Also note the door close action now triggers the
warning beep.
